### PR TITLE
Always delete the table if empty == true

### DIFF
--- a/luigi_bigquery/targets/bq.py
+++ b/luigi_bigquery/targets/bq.py
@@ -36,11 +36,8 @@ class TableTarget(luigi.Target):
         count = table.get('numRows', 0)
 
         if self.empty:
-            if count == 0:
-                return True
-            else:
-                logger.info('Deleting table: %s.%s', self.dataset_id, self.table_id)
-                client.delete_table(self.dataset_id, self.table_id)
-                return False
+            logger.info('Deleting table: %s.%s', self.dataset_id, self.table_id)
+            client.delete_table(self.dataset_id, self.table_id)
+            return False
         else:
             return True

--- a/luigi_bigquery/tests/test_targets_bq.py
+++ b/luigi_bigquery/tests/test_targets_bq.py
@@ -60,4 +60,4 @@ class TableTargetTestCase(TestCase):
 
     def test_exists_check_empty(self):
         eq_(TableTarget('dataset_1', 'table_1', empty=True, config=test_config).exists(), False)
-        eq_(TableTarget('dataset_1', 'table_2', empty=True, config=test_config).exists(), True)
+        eq_(TableTarget('dataset_1', 'table_2', empty=True, config=test_config).exists(), False)


### PR DESCRIPTION
Shouldn't the table always be deleted if empty == true? Since we explicitly tell say we want to, I don't think there should be a constraint if the table is actually empty or not.
